### PR TITLE
Modify 8.md for blog integration

### DIFF
--- a/src/content/blog/8.md
+++ b/src/content/blog/8.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cursor Mobile×Obsidian：日々の記録からブログへ自動投稿する新しいワークフロー'
 description: 'Cursor MobileとObsidianを連携させて、日常の思考やアイデアを効率的にブログコンテンツに変換する革新的なシステム'
-pubDate: '2025-01-15'
+pubDate: '2025-07-01'
 heroImage: '/blog-placeholder-4.jpg'
 published: true
 ---

--- a/src/content/blog/8.md
+++ b/src/content/blog/8.md
@@ -1,208 +1,259 @@
 ---
-title: 'Cursor×Obsidian連携の可能性：MCPアーキテクチャで実現する次世代開発環境'
-description: 'CursorのModel Context Protocol（MCP）とObsidianの連携により実現する、革新的な開発ワークフローとセカンドブレイン構築の詳細分析'
+title: 'Cursor Mobile×Obsidian：日々の記録からブログへ自動投稿する新しいワークフロー'
+description: 'Cursor MobileとObsidianを連携させて、日常の思考やアイデアを効率的にブログコンテンツに変換する革新的なシステム'
 pubDate: '2025-01-15'
 heroImage: '/blog-placeholder-4.jpg'
 published: true
 ---
 
-AI駆動のコードエディタ**Cursor**と知識管理ツール**Obsidian**の連携が、開発者の生産性を劇的に向上させる可能性について詳しく分析してみたい。特に、CursorのModel Context Protocol（MCP）を活用した統合アプローチに焦点を当てる。
+日々の思考やアイデアを記録することは重要だが、それをブログという形でアウトプットするのは意外と大変な作業だ。今回、**Cursor Mobile**と**Obsidian**を組み合わせることで、日々の記録から自動的にブログ投稿を生成する革新的なワークフローを構築した。その詳細を紹介したい。
 
-![AI Development](https://images.unsplash.com/photo-1555949963-aa79dcee981c?w=800&h=400&fit=crop)
+![Mobile Writing](https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=800&h=400&fit=crop)
 
-## Cursorの技術的進化
+## なぜObsidianとCursor Mobileの組み合わせなのか？
 
-### MCPプロトコルの革新性
+### Obsidianの強み
+- **ローカルMarkdownファイル**: プレーンテキストで将来性が高い
+- **Gitとの相性**: バージョン管理が容易
+- **リンク機能**: アイデア間の関連性を可視化
+- **プラグインエコシステム**: 機能拡張が豊富
 
-CursorのModel Context Protocol（MCP）は、Anthropicが開発した「AIアプリケーションのUSB-Cポート」とも呼べる標準プロトコルだ。これにより以下が実現される：
+### Cursor Mobileの革新性
+- **AIアシスタント統合**: 自然言語でのコード生成・編集
+- **モバイル最適化**: いつでもどこでも開発可能
+- **リアルタイム同期**: デスクトップ版との完全同期
 
-- **動的ツール発見機能**: AIが新しい機能を自動発見
-- **標準化されたメッセージ交換**: JSON-RPC 2.0による効率的な通信
-- **柔軟なトランスポート層**: stdio、HTTP with SSEなど複数の接続方式
+この組み合わせにより、思考の記録から公開までのフローが劇的に効率化される。
 
-```typescript
-// MCP サーバーの基本構造
-export const server = new McpServer({
-  name: "obsidian",
-  version: "1.0.0",
-});
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
-```
-
-### Copilot++による次世代予測
-
-GitHub Copilotを超える**Copilot++**では、単なるコード補完を超えて：
-
-- **Next Action Prediction**: 次のファイル移動やターミナルコマンドを予測
-- **Speculative Edits**: 推測的編集による低レイテンシ実現
-- **Perfect Edits**: 非同期バックグラウンド編集とフロー保持の両立
-
-![Code Prediction](https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800&h=400&fit=crop)
-
-## Obsidianとの連携アーキテクチャ
-
-### ファイルシステム直接アクセスによる統合
-
-Obsidianは本質的にMarkdownファイルのディレクトリなので、MCPサーバーはObsidianアプリケーションを起動せずに直接操作可能だ：
-
-```typescript
-const obsidianTools = [
-  {
-    name: "getAllFilenames",
-    description: "Obsidianボルト内の全ファイル名を取得",
-    handler: () => { /* 実装 */ }
-  },
-  {
-    name: "readMultipleFiles", 
-    description: "指定されたファイルの内容を取得",
-    handler: () => { /* 柔軟な検索と読み込み */ }
-  },
-  {
-    name: "updateFileContent",
-    description: "ファイル内容の更新/作成",
-    handler: () => { /* ディレクトリ自動作成対応 */ }
-  },
-  {
-    name: "getOpenTodos",
-    description: "未完了TODOアイテムの取得",
-    handler: () => { /* "- [ ]" パターンスキャン */ }
-  }
-];
-```
-
-### MCPトランスポートタイプの比較
-
-| タイプ | 実行環境 | デプロイメント | ユーザー | 認証 |
-|--------|----------|----------------|----------|------|
-| **stdio** | ローカル | Cursor管理 | シングル | 手動 |
-| **SSE** | ローカル/リモート | サーバー | マルチ | OAuth |
-| **HTTP** | ローカル/リモート | サーバー | マルチ | OAuth |
-
-## 実現可能な革新的ワークフロー
+## システム構成とワークフロー
 
 ![Knowledge Management](https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=800&h=400&fit=crop)
 
-### セカンドブレイン強化機能
+### 1. Obsidianでの日々の記録
 
-```typescript
-// 知識管理の自動化例
-"今日のコード変更についてスタンドアップ用のノートを作成"
-// → git履歴分析 + 新ノート作成
+日常的にObsidianで以下のような記録を蓄積している：
 
-"リファクタリング関連のTODOを確認して実装"  
-// → TODO検索 + コード変更の実行
+```markdown
+# 2025-01-15 デイリーノート
 
-"TODOの優先順位付けプランを作成"
-// → 分析 + 戦略ドキュメント生成
+## 今日の学び
+- Cursor MobileのWebブラウザ版が想像以上に使いやすい
+- Obsidianのデイリーノートテンプレートを改良した
+
+## アイデア
+- ブログ記事：Obsidian→ブログの自動化について
+- 開発メモ：GitHub Actionsでの自動デプロイ
+
+## 開発ログ
+- ブログのコンポーネント修正
+- CSS の responsive design 改善
 ```
 
-### コンテキスト共有システム
+### 2. リポジトリ構成
 
-- **統一知識ベース**: コード + ドキュメント + アイデアの一元管理
-- **クロスリファレンス**: コードとノート間の自動リンク生成
-- **バージョン管理**: git履歴とノートの完全同期
-
-## Cursorの今後のロードマップ（2024-2025）
-
-### Optimal Context（最適コンテキスト）
 ```
-課題: 数百万トークンの情報を効率的に処理
-- ドキュメント: 数百万トークン
-- ソースコード: 数千万トークン  
-- コミット履歴: 数千万トークン
-- UI、ログ、Slack等: 追加の数百万トークン
+📁 obsidian-notes/          # Obsidianボルト（Gitリポジトリ）
+├── 📁 Daily Notes/
+├── 📁 Projects/
+├── 📁 Ideas/
+└── 📁 Blog Drafts/          # ブログ下書き専用フォルダ
+
+📁 blog-repository/          # ブログサイトのリポジトリ
+├── 📁 src/content/blog/
+├── 📁 public/
+└── 📁 scripts/              # 自動化スクリプト
 ```
 
-**技術革新**:
-- **Multi-hop Context**: 複数ホップを要する複雑クエリの解決
-- **Differentiable Search Index**: Transformer メモリを検索インデックスとして活用
-- **カスタムアテンションマスク**: コードベース特化型
+### 3. Cursor Mobileでの変換作業
 
-### Perfect Editsによる非同期編集
+移動時間や空き時間に、iPhoneでCursor Mobileを開いて作業する：
 
-![Async Editing](https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=800&h=400&fit=crop)
+```
+私: 「今日のObsidianの記録を見て、ブログ記事にできそうなネタを探して」
+Cursor: Daily Noteを分析して候補を提示
 
-**革新的機能**:
-- **Hallucinated Pseudocode**: 存在しない関数を実装してからバックグラウンドで生成
-- **Multi-File Edits**: コードベース全体にわたる包括的な編集
+私: 「Cursor MobileとObsidianの連携について記事を書いて」
+Cursor: 構成を提案し、Markdownで記事を生成
 
-### Bug Detection and Debugging
-- **AI Review**: プロアクティブなコードレビュー
-- **AI Linting**: 常時バックグラウンド実行
-- **Smarter Debugging**: ランタイム情報追跡
-
-## 技術的課題と解決策
-
-### スケーラビリティへの対応
-- **現在**: 14億ベクトル、15万コードベース
-- **予想**: 年末までに10倍成長
-- **解決策**: Rustカスタムインデックスシステム
-
-### レイテンシ最適化戦略
-- **Prefill-bound predictions**: 高速な事前入力
-- **Custom inference infrastructure**: 推論インフラの最適化
-- **Edge computing**: エッジでの計算分散
-
-![Performance](https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800&h=400&fit=crop)
-
-## 実装ガイドと設定例
-
-### Cursor設定での統合
-
-```json
-// Claude Desktop設定例
-{
-  "mcpServers": {
-    "obsidian": {
-      "command": "node", 
-      "args": [
-        "obsidian-mcp-server/build/index.js",
-        "/path/to/your/vault"
-      ]
-    }
-  }
-}
+私: 「もう少し具体的な手順を追加して」
+Cursor: 実際の使用例を含めて内容を拡充
 ```
 
-```bash
-# Cursor MCP設定例
-node obsidian-mcp-server/build/index.js /path/to/your/vault
+![Mobile Development](https://images.unsplash.com/photo-1677442136019-21780ecad995?w=800&h=400&fit=crop)
+
+## 実装の詳細
+
+### Obsidianテンプレート設定
+
+デイリーノート用のテンプレートを作成：
+
+```markdown
+# {{date}} デイリーノート
+
+## 今日の学び
+- 
+
+## アイデア
+- 
+
+## 開発ログ
+- 
+
+## ブログ候補
+- [ ] 
+- [ ] 
+
+## リンク
+[[昨日のノート]] | [[明日のノート]]
 ```
 
-### 開発ワークフロー統合手順
-1. **Setup**: ワンクリックOAuth認証
-2. **Configuration**: プロジェクト固有設定（.cursor/mcp.json）
-3. **Global Tools**: ホームディレクトリ設定（~/.cursor/mcp.json）
+### GitHub Actions自動化
 
-## 将来への展望
+Obsidianリポジトリの更新をトリガーにして、ブログ記事の候補を自動抽出：
+
+```yaml
+name: Blog Content Sync
+on:
+  push:
+    paths:
+      - 'Blog Drafts/**'
+      - 'Daily Notes/**'
+
+jobs:
+  sync-content:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Blog Candidates
+        run: |
+          # 特定のタグやキーワードを含むノートを抽出
+          # ブログリポジトリに自動PRを作成
+```
+
+### Cursor Mobileでの編集プロセス
+
+1. **コンテンツ抽出**: Obsidianの記録から興味深いポイントを抽出
+2. **構成生成**: ブログ記事として適切な構成に再編成
+3. **肉付け**: 読者にとって有益な情報を追加
+4. **メタデータ生成**: タイトル、説明文、タグなどを自動生成
+
+## 実際の使用例
+
+![Blog Writing](https://images.unsplash.com/photo-1486312338219-ce68d2c6f44d?w=800&h=400&fit=crop)
+
+### ケース1: 学習記録からチュートリアル記事へ
+
+**Obsidianでの記録**:
+```markdown
+## 今日の学び
+- Next.js 14のServer Actionsを試した
+- フォームバリデーションがすごく楽になった
+- 従来のAPI Routesと比較して約30%コード削減
+```
+
+**Cursor Mobileでの変換**:
+```
+私: 「Server Actionsの学習記録をチュートリアル記事にして」
+Cursor: → 「Next.js 14 Server Actionsで変わるフォーム処理：実践ガイド」
+```
+
+### ケース2: アイデアメモから考察記事へ
+
+**Obsidianでの記録**:
+```markdown
+## アイデア
+- AIツールが増えすぎて選択疲れが起きている
+- ツールの組み合わせ方が重要
+- 個人的なワークフローの最適化が必要
+```
+
+**Cursor Mobileでの変換**:
+```
+私: 「AIツールの選択疲れについて記事を書いて」
+Cursor: → 「AI時代の生産性向上：ツール選択から統合ワークフローまで」
+```
+
+## メリットと課題
+
+### メリット
+
+**継続性の向上**
+- 記録のハードルが低い（いつものObsidian作業）
+- モバイルでの隙間時間活用
+- 思考の連続性を保持
+
+**品質の向上**
+- AIによる構成提案
+- 過去の記録との関連性自動抽出
+- 一貫したトーン&マナー
+
+**効率性**
+- 記録→公開までの時間短縮
+- 手動コピペ作業の削減
+- バージョン管理の自動化
+
+### 課題と対策
+
+**情報の重複**
+- 課題: 同じような記録が複数存在
+- 対策: タグシステムとリンク機能の活用
+
+**プライバシー管理**
+- 課題: 個人的な記録も含まれる
+- 対策: ブログ用フォルダの明確な分離
+
+**技術的依存**
+- 課題: ツールの組み合わせが複雑
+- 対策: シンプルなバックアップシステム
 
 ![Future Technology](https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=800&h=400&fit=crop)
 
-### 短期的推奨事項（3-6ヶ月）
-1. **基本的Obsidian MCP実装**: ファイルシステムベースの連携
-2. **プロトタイプ開発**: TODO管理とノート生成の自動化
-3. **ユーザビリティテスト**: 実際の開発ワークフローでの検証
+## 今後の改善計画
 
-### 中期的展望（6-12ヶ月）  
-1. **高度なコンテキスト管理**: マルチホップ検索の実装
-2. **セマンティック検索**: ベクトル検索とキーワード検索のハイブリッド
-3. **リアルタイム同期**: Obsidianアプリとの双方向同期
+### 短期的改善（1-2ヶ月）
+1. **テンプレートの洗練**: より効率的な記録フォーマット
+2. **タグシステム**: ブログ候補の自動識別
+3. **画像管理**: Obsidianの画像とブログの連携
 
-### 長期的ビジョン（1-2年）
-1. **完全統合セカンドブレイン**: コードと知識の完全一体化
-2. **予測的ワークフロー**: 次のアクションの自動提案と実行
-3. **コラボレーション機能**: チーム全体でのナレッジ共有
+### 中期的改善（3-6ヶ月）
+1. **AI分析**: 記録の傾向分析とネタ提案
+2. **自動スケジューリング**: 投稿タイミングの最適化
+3. **SEO最適化**: キーワード分析と最適化提案
+
+### 長期的ビジョン（6ヶ月以上）
+1. **音声入力統合**: 音声メモからテキスト化
+2. **マルチプラットフォーム**: 複数のブログサイトへの同時投稿
+3. **コミュニティ機能**: 読者フィードバックの自動取り込み
+
+## 実践のためのスタートガイド
+
+### 必要なツール
+- **Obsidian** (無料)
+- **Cursor Mobile** (ブラウザ版無料)
+- **GitHub** (パブリックリポジトリは無料)
+
+### セットアップ手順
+1. Obsidianでボルトを作成
+2. GitHubリポジトリとして初期化
+3. デイリーノートテンプレート設定
+4. ブログリポジトリとの連携設定
+
+### 初日からできること
+- デイリーノートの記録開始
+- 週に1回のブログ記事変換
+- 段階的な自動化の導入
+
+![Success](https://images.unsplash.com/photo-1518709268805-4e9042af2176?w=800&h=400&fit=crop)
 
 ## まとめ
 
-CursorとObsidianの連携は、単なるツールの組み合わせを超えて、**開発者の思考プロセス自体を拡張**する可能性を秘めている。
+Cursor MobileとObsidianの組み合わせにより、**思考の記録から情報発信までの一連のフロー**が劇的に改善された。
 
-MCPプロトコルの成熟により、コードと知識が完全に統合された開発環境が実現し、我々の生産性とクリエイティビティが飛躍的に向上することが期待される。
+重要なのは、完璧なシステムを最初から構築しようとするのではなく、シンプルに始めて徐々に改善していくことだ。日々の小さな記録が、やがて価値のあるコンテンツに変わっていく。
 
-この技術革新の波に乗り遅れることなく、新しい開発パラダイムを積極的に取り入れていこう。未来の開発体験は、もうすぐそこまで来ている。
+この記事で紹介したワークフローは、知識労働者や個人ブロガーにとって非常に有効なアプローチだと確信している。ぜひ自分なりにカスタマイズして活用してほしい。
+
+**今日から始められる。明日にはもう結果が見える。そんな時代に私たちは生きている。**
 
 ---
 
-*この分析レポートは、CursorとObsidianの技術的可能性を深く掘り下げたものです。実際の統合実装にチャレンジしてみませんか？*
+*この記事も、Obsidianの記録をもとにCursor Mobileで作成した。新しい情報発信のスタイルを一緒に探求してみませんか？*


### PR DESCRIPTION
Rewrite `src/content/blog/8.md` to describe a workflow for turning Obsidian daily notes into blog posts using Cursor Mobile, removing the previous focus on MCP/Copilot and updating the publication date.